### PR TITLE
Fix compile error on VS 2017

### DIFF
--- a/TeaFiles/time/TimeScale.h
+++ b/TeaFiles/time/TimeScale.h
@@ -18,6 +18,7 @@ public:
   static TimeScale& Java();
   static TimeScale& Net();
 
+  TimeScale() {}
   TimeScale(int64 epoch, int64 ticksPerDay);
 
   int64 Epoch() const;


### PR DESCRIPTION
* Add default constructor to TimeScale to fix `error C2512: 'teatime::TimeScale': no appropriate default constructor available`.